### PR TITLE
Support for Delete HTTP Method

### DIFF
--- a/test.go
+++ b/test.go
@@ -113,6 +113,51 @@ func (t *Test) Get(baseURL, endpoint string, result interface{}) *Test {
 	return t
 }
 
+// Delete deletes data from a specified endpoint.
+func (t *Test) Delete(baseURL, endpoint string, result interface{}) *Test {
+	if t.Error != nil {
+		return t
+	}
+
+	addr, err := url.Parse(baseURL + endpoint)
+	if err != nil {
+		t.Error = err
+		return t
+	}
+
+	req, err := http.NewRequest("DELETE", addr.String(), nil)
+	if err != nil {
+		t.Error = err
+		return t
+	}
+
+	res, err := t.Client.Do(req)
+	if err != nil {
+		t.Error = err
+		return t
+	}
+
+	t.Response = res
+	t.Status = res.StatusCode
+
+	body := res.Body
+	defer body.Close()
+
+	resultBody, err := ioutil.ReadAll(res.Body)
+
+	if err != nil {
+		t.Error = err
+		return t
+	}
+
+	if err := json.Unmarshal(resultBody, result); err != nil {
+		t.Error = err
+		return t
+	}
+
+	return t
+}
+
 // Put sends a HTTP PUT request with given URL from baseURL combined with
 // endpoint and then saves the result.
 func (t *Test) Post(baseURL, endpoint string, data, result interface{}) *Test {

--- a/test_test.go
+++ b/test_test.go
@@ -17,14 +17,14 @@ type SampleObject struct {
 }
 
 func init() {
+	data, _ := json.Marshal(SampleObject{
+		Name:    "unit-test",
+		Value:   100,
+		Success: true,
+	})
 	api = httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "POST" {
-				data, _ := json.Marshal(SampleObject{
-					Name:    "unit-test",
-					Value:   100,
-					Success: true,
-				})
 				cookie := &http.Cookie{
 					Name:  "test-cookie",
 					Value: "unit-test-sample-value",
@@ -33,11 +33,15 @@ func init() {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusCreated)
 				w.Write(data)
+			} else if r.Method == "GET" {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write(data)
 			}
 		}))
 }
 
-func TestIRestSetup(t *testing.T) {
+func TestSetup(t *testing.T) {
 	test := NewTest("unit-test")
 
 	if test.Name != "unit-test" {
@@ -45,7 +49,7 @@ func TestIRestSetup(t *testing.T) {
 	}
 }
 
-func TestIRestPost(t *testing.T) {
+func TestPost(t *testing.T) {
 	test := NewTest("unit-test")
 
 	sample := SampleObject{}
@@ -58,7 +62,7 @@ func TestIRestPost(t *testing.T) {
 	}
 }
 
-func TestIRestPostMustStatus(t *testing.T) {
+func TestPostMustStatus(t *testing.T) {
 	test := NewTest("unit-test")
 
 	sample := SampleObject{}
@@ -68,7 +72,7 @@ func TestIRestPostMustStatus(t *testing.T) {
 	}
 }
 
-func TestIRestPostSaveCookie(t *testing.T) {
+func TestPostSaveCookie(t *testing.T) {
 	test := NewTest("unit-test")
 
 	sample := SampleObject{}
@@ -81,6 +85,16 @@ func TestIRestPostSaveCookie(t *testing.T) {
 
 	if cookie.Value != "unit-test-sample-value" {
 		t.Errorf("expected cookie value to be 'unit-test-sample-value', got '%s'", cookie)
+	}
+}
+
+func TestGet(t *testing.T) {
+	test := NewTest("unit-test")
+	sample := SampleObject{}
+	test = test.Get(api.URL, "/tests", &sample).MustStatus(http.StatusOK).MustStringValue(sample.Name, "unit-test")
+
+	if test.Error != nil {
+		t.Error(test.Error)
 	}
 }
 


### PR DESCRIPTION
Allow for Post, Put, Get, and Delete now.

Show in tests how to start chaining calls and making more complex tests and test case setup.