### PR TITLE
Default Headers

### DIFF
--- a/test.go
+++ b/test.go
@@ -58,6 +58,10 @@ func (t *Test) NewTest(name string) *Test {
 
 	t.Tests = append(t.Tests, testCase)
 
+	// For convenience, bring down header values that were set on the
+	// parent test.
+	testCase.Header = t.Header
+
 	return testCase
 }
 

--- a/test_test.go
+++ b/test_test.go
@@ -71,6 +71,17 @@ func TestPost(t *testing.T) {
 	}
 }
 
+func TestAddDefaultHeader(t *testing.T) {
+	test := NewTest("unit-test").
+		AddHeader("Content-Type", "application/json")
+
+	subTest := test.NewTest("sub-test")
+
+	if subTest.Header.Get("Content-Type") == "" {
+		t.Error("expected Content-Type to be set")
+	}
+}
+
 func TestPostMustStatus(t *testing.T) {
 	test := NewTest("unit-test")
 


### PR DESCRIPTION
Allow for setting default headers by children of tests to inherit previously set headers.