### PR TITLE
Add example reports output.

### DIFF
--- a/cmd/example_report/example_report.go
+++ b/cmd/example_report/example_report.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/bsedg/irest"
+)
+
+func main() {
+	t := irest.NewTest("example")
+
+	// Example tests with artificial data.
+	t1 := t.NewTest("example - 1")
+	t1.Duration = 50
+	t1.Endpoint = "/examples/1"
+	t1.Error = nil
+
+	t2 := t.NewTest("example - 2")
+	t2.Duration = 400
+	t2.Endpoint = "/examples/2"
+	t2.Error = fmt.Errorf("expected different result")
+
+	r := irest.NewColoredCommandLineReport(t)
+	r.PrintResults()
+}

--- a/reports.go
+++ b/reports.go
@@ -1,0 +1,83 @@
+package irest
+
+import (
+	"fmt"
+)
+
+type Report struct {
+	InfoLabel     string
+	PassTestLabel string
+	FailTestLabel string
+	TimingHeader  string
+
+	Test *Test
+}
+
+// NewDefaultReport sets outputs to use ANSI color codes
+// and unicode check and x.
+func NewColoredCommandLineReport(t *Test) *Report {
+	return &Report{
+		InfoLabel:     "[ \033[00;96m\xE2\x8B\xAE\033[0m ]",
+		PassTestLabel: "[ \033[00;32m\xE2\x9C\x93\033[0m ]",
+		FailTestLabel: "[ \033[00;31m\xE2\x9C\x98\033[0m ]",
+		TimingHeader:  "[   ms   ]",
+		Test:          t,
+	}
+}
+
+// PrintResults outputs report to stdout based on report fields.
+func (r *Report) PrintResults() error {
+	if r.Test == nil {
+		return fmt.Errorf("Report.Test must be set")
+	}
+
+	fmt.Printf("%s %s %s\n", r.InfoLabel, r.TimingHeader, r.Test.Name)
+
+	testStack := []*Test{}
+	testStack = append(testStack, r.Test.Tests...)
+	for len(testStack) > 0 {
+		next := testStack[len(testStack)-1]
+		r.printResult(next)
+		if next.Tests != nil || len(next.Tests) > 0 {
+			// Remove last test in stack.
+			testStack = append(testStack[:0], testStack[:len(testStack)-1]...)
+
+			// Add all sub tests of next test.
+			testStack = append(testStack, next.Tests...)
+		}
+	}
+
+	return nil
+}
+
+func (r *Report) printResult(t *Test) {
+	var timing string
+
+	// TODO: create thresholds that can be specified.
+	if t.Duration == 0 && t.Response == nil {
+		timing = "[      ]"
+	} else if t.Duration < 100 {
+		timing = fmt.Sprintf("[ \033[00;32m%3d ms\033[0m ]", t.Duration)
+	} else if t.Duration < 500 {
+		timing = fmt.Sprintf("[ \033[00;33m%3d ms\033[0m ]", t.Duration)
+	} else {
+		timing = fmt.Sprintf("[ \033[00;31m%3d ms\033[0m ]", t.Duration)
+	}
+
+	// Indents test by a separator to show groupings of tests.
+	indent := ""
+	for i := 0; i < t.Depth; i++ {
+		indent += "-"
+	}
+
+	msg := t.Name
+	var result string
+	if t.Error == nil {
+		result = r.PassTestLabel
+	} else {
+		result = r.FailTestLabel
+		msg += fmt.Sprintf(" (%s) for %s", t.Error, t.Endpoint)
+	}
+
+	fmt.Printf("%s %s %s %s\n", result, timing, indent, msg)
+}

--- a/test.go
+++ b/test.go
@@ -16,9 +16,15 @@ import (
 // Test struct contains sub-tests that can be isolated test cases as well
 // as the HTTP related objects and errors of current test and its sub-tests.
 type Test struct {
-	Name     string `json:"name"`
-	Error    error  `json:"err"`
-	Status   int    `json:"status"`
+	Name  string `json:"name"`
+	Error error  `json:"err"`
+
+	// Depth is useful for reporting.
+	Depth int `json:"depth"`
+
+	Endpoint string `json:"endpoint"`
+
+	Status   int `json:"status"`
 	Tests    []*Test
 	Errors   []error
 	Created  time.Time `json:"created"`
@@ -36,6 +42,7 @@ func NewTest(name string) *Test {
 	t := &Test{
 		Name:    name,
 		Error:   nil,
+		Depth:   0,
 		Tests:   []*Test{},
 		Errors:  []error{},
 		Created: time.Now(),
@@ -51,6 +58,7 @@ func NewTest(name string) *Test {
 func (t *Test) NewTest(name string) *Test {
 	testCase := &Test{
 		Name:   name,
+		Depth:  t.Depth + 1,
 		Tests:  []*Test{},
 		Client: t.Client,
 		Header: &http.Header{},
@@ -106,6 +114,8 @@ func (t *Test) do(method, baseURL, endpoint string, data interface{}) *Test {
 		t.Error = err
 		return t
 	}
+
+	t.Endpoint = endpoint
 
 	b := new(bytes.Buffer)
 	if data != nil {


### PR DESCRIPTION
Adds `reports.go` with example code using it in `cmd/example_report/example_report.go`.

Running the `example_report` with `go build cmd/example_report/example_report.go && ./example_report`, the output will be:
![example_report](https://cloud.githubusercontent.com/assets/713589/19022297/386a5b8e-88a3-11e6-9264-a6eac6f2e260.png)
