### PR TITLE
Adds Makefile for encapsulated commands 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,6 @@ build:
 	@echo "+ $@"
 	@go build .
 
-build_example:
-	@echo "+ $@"
-	@go build cmd/example_report/example_report.go
-
 clean:
 	@echo "+ $@"
 	@rm -f example_report $(COVERPROFILE)
@@ -19,6 +15,10 @@ cover:
 	@echo "+ $@"
 	@go test -coverprofile=$(COVERPROFILE) .
 	@go tool cover -html=$(COVERPROFILE)
+
+example:
+	@echo "+ $@"
+	@go build cmd/example_report/example_report.go
 
 fmt:
 	@echo "+ $@"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+PACKAGES=$(shell go list ./... | grep -v /vendor/)
+COVERPROFILE=cover.out
+
+all: clean build fmt lint test vet
+
+build:
+	@echo "+ $@"
+	@go build .
+
+build_example:
+	@echo "+ $@"
+	@go build cmd/example_report/example_report.go
+
+clean:
+	@echo "+ $@"
+	@rm -f example_report $(COVERPROFILE)
+
+cover:
+	@echo "+ $@"
+	@go test -coverprofile=$(COVERPROFILE) .
+	@go tool cover -html=$(COVERPROFILE)
+
+fmt:
+	@echo "+ $@"
+	@gofmt -s -l . | grep -v vendor | tee /dev/stderr
+
+lint:
+	@echo "+ $@"
+	@golint ./... | grep -v vendor | tee /dev/stderr
+
+test: fmt lint vet
+	@echo "+ $@"
+	@go test -v $(shell go list ./... | grep -v vendor)
+
+vet:
+	@echo "+ $@"
+	@go vet $(shell go list ./... | grep -v vendor)

--- a/reports.go
+++ b/reports.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 )
 
+// Report provides test to output results for as well as various fields for
+// display purposes.
 type Report struct {
 	InfoLabel     string
 	PassTestLabel string
@@ -13,7 +15,7 @@ type Report struct {
 	Test *Test
 }
 
-// NewDefaultReport sets outputs to use ANSI color codes
+// NewColoredCommandLineReport sets outputs to use ANSI color codes
 // and unicode check and x.
 func NewColoredCommandLineReport(t *Test) *Report {
 	return &Report{


### PR DESCRIPTION
Adds Makefile.

`make` will execute `clean build fmt lint test vet`

You can do `make build` to just build.

To build the example in order to run it locally to view the results, run `make example`.

Then view the test coverage via html, run `make cover`.