### PR TITLE
Addresses #23: test.go (close) to 100% coverage

### DIFF
--- a/test.go
+++ b/test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"time"
 )
 
@@ -106,12 +105,6 @@ func (t *Test) Delete(baseURL, endpoint string) *Test {
 }
 
 func (t *Test) do(method, baseURL, endpoint string, data interface{}) *Test {
-	addr, err := url.Parse(baseURL + endpoint)
-	if err != nil {
-		t.Error = err
-		return t
-	}
-
 	t.Endpoint = endpoint
 
 	b := new(bytes.Buffer)
@@ -122,7 +115,7 @@ func (t *Test) do(method, baseURL, endpoint string, data interface{}) *Test {
 		}
 	}
 
-	req, err := http.NewRequest(method, addr.String(), b)
+	req, err := http.NewRequest(method, baseURL+endpoint, b)
 	if err != nil {
 		t.Error = err
 		return t

--- a/test_test.go
+++ b/test_test.go
@@ -123,6 +123,16 @@ func TestRequestFailure(t *testing.T) {
 	}
 }
 
+func TestParseResponseBodyEmptyResponse(t *testing.T) {
+	test := NewTest("unit-test")
+
+	test = test.ParseResponseBody(nil)
+
+	if test.Error == nil {
+		t.Errorf("expected an error, but did not get one")
+	}
+}
+
 func TestAddDefaultHeader(t *testing.T) {
 	test := NewTest("unit-test").
 		AddHeader("Content-Type", "application/json")

--- a/test_test.go
+++ b/test_test.go
@@ -82,6 +82,16 @@ func TestAddDefaultHeader(t *testing.T) {
 	}
 }
 
+func TestAddCookie(t *testing.T) {
+	cookie := &http.Cookie{Name: "test-cookie", Value: "test-value"}
+	test := NewTest("unit-test").
+		AddCookie(cookie)
+
+	if test.Cookies[0] != cookie {
+		t.Error("expected cookie to be set")
+	}
+}
+
 func TestPostMustStatus(t *testing.T) {
 	test := NewTest("unit-test")
 

--- a/test_test.go
+++ b/test_test.go
@@ -95,6 +95,15 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestMalformedUrl(t *testing.T) {
+	test := NewTest("unit-test")
+
+	test = test.Get(api.URL, "bad-url%@%(*%)///\\####")
+	if test.Error == nil {
+		t.Errorf("expected an error, but did not get one")
+	}
+}
+
 func TestAddDefaultHeader(t *testing.T) {
 	test := NewTest("unit-test").
 		AddHeader("Content-Type", "application/json")

--- a/test_test.go
+++ b/test_test.go
@@ -114,6 +114,15 @@ func TestBadRequestBody(t *testing.T) {
 	}
 }
 
+func TestRequestFailure(t *testing.T) {
+	test := NewTest("unit-test")
+
+	test = test.Get("", "")
+	if test.Error == nil {
+		t.Errorf("expected an error, but did not get one")
+	}
+}
+
 func TestAddDefaultHeader(t *testing.T) {
 	test := NewTest("unit-test").
 		AddHeader("Content-Type", "application/json")

--- a/test_test.go
+++ b/test_test.go
@@ -20,7 +20,7 @@ type SampleObject struct {
 func init() {
 	api = httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == "POST" || r.Method == "PUT" {
+			if r.Method == http.MethodPost || r.Method == http.MethodPut {
 				data, _ := json.Marshal(SampleObject{
 					Name:    "unit-test",
 					Value:   100,
@@ -36,7 +36,7 @@ func init() {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusCreated)
 				w.Write(data)
-			} else if r.Method == "GET" {
+			} else if r.Method == http.MethodGet {
 				data, _ := json.Marshal(SampleObject{
 					Name:    "unit-test",
 					Value:   100,
@@ -46,7 +46,7 @@ func init() {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				w.Write(data)
-			} else if r.Method == "DELETE" {
+			} else if r.Method == http.MethodDelete {
 				w.WriteHeader(http.StatusNoContent)
 			}
 		}))

--- a/test_test.go
+++ b/test_test.go
@@ -246,6 +246,27 @@ func TestMustStringValueMismatch(t *testing.T) {
 	}
 }
 
+func TestMustIntValueError(t *testing.T) {
+	test := NewTest("unit-test")
+
+	test.Error = fmt.Errorf("testing error")
+	test = test.MustIntValue(42, 42)
+
+	if test.Error == nil {
+		t.Errorf("expected an error, but did not get one")
+	}
+}
+
+func TestMustIntValueMismatch(t *testing.T) {
+	test := NewTest("unit-test")
+
+	test = test.MustIntValue(42, 43)
+
+	if test.Error == nil {
+		t.Errorf("expected an error, but did not get one")
+	}
+}
+
 func TestMustFunction(t *testing.T) {
 	test := NewTest("unit-test")
 

--- a/test_test.go
+++ b/test_test.go
@@ -46,6 +46,8 @@ func init() {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				w.Write(data)
+			} else if r.Method == "DELETE" {
+				w.WriteHeader(http.StatusNoContent)
 			}
 		}))
 }
@@ -81,6 +83,15 @@ func TestPut(t *testing.T) {
 	}
 	if !sample.Success {
 		t.Error("expected response success to be true")
+	}
+}
+
+func TestDelete(t *testing.T) {
+	test := NewTest("unit-test")
+
+	test = test.Delete(api.URL, "/tests")
+	if test.Status != http.StatusNoContent {
+		t.Errorf("expected status 204 No Content, instead was %d", test.Status)
 	}
 }
 

--- a/test_test.go
+++ b/test_test.go
@@ -203,6 +203,28 @@ func mustNil() error {
 	return fmt.Errorf("must function error")
 }
 
+func TestMustStatusError(t *testing.T) {
+	test := NewTest("unit-test")
+
+	test.Error = fmt.Errorf("testing error")
+	test = test.MustStatus(500)
+
+	if test.Error == nil {
+		t.Errorf("expected an error, but did not get one")
+	}
+}
+
+func TestMustStatusMismatch(t *testing.T) {
+	test := NewTest("unit-test")
+
+	test.Status = 418
+	test = test.MustStatus(451)
+
+	if test.Error == nil {
+		t.Errorf("expected an error, but did not get one")
+	}
+}
+
 func TestMustFunction(t *testing.T) {
 	test := NewTest("unit-test")
 

--- a/test_test.go
+++ b/test_test.go
@@ -130,6 +130,7 @@ func TestAddCookie(t *testing.T) {
 	test := NewTest("unit-test").
 		AddCookie(cookie)
 
+	test = test.Get(api.URL, "/tests")
 	if test.Cookies[0] != cookie {
 		t.Error("expected cookie to be set")
 	}

--- a/test_test.go
+++ b/test_test.go
@@ -278,6 +278,49 @@ func TestMustError(t *testing.T) {
 	}
 }
 
+func TestSaveCookieError(t *testing.T) {
+	test := NewTest("unit-test")
+
+	test.Error = fmt.Errorf("testing error")
+	test = test.SaveCookie("test-cookie", &http.Cookie{})
+
+	if test.Error == nil {
+		t.Errorf("expected an error, but did not get one")
+	}
+}
+
+func TestSaveCookieNoResponse(t *testing.T) {
+	test := NewTest("unit-test")
+
+	test = test.SaveCookie("test-cookie", &http.Cookie{})
+
+	if test.Error == nil {
+		t.Errorf("expected an error, but did not get one")
+	}
+
+	msg := "http response not set, must have request before saving result"
+	if test.Error.Error() != msg {
+		t.Errorf("expected '%s', got '%s' instead", msg, test.Error.Error())
+	}
+}
+
+func TestSaveCookieDoesNotExist(t *testing.T) {
+	test := NewTest("unit-test")
+
+	cookie := &http.Cookie{}
+	test = test.Post(api.URL, "/tests", nil).
+		SaveCookie("nonexistent-cookie", cookie)
+
+	if test.Error == nil {
+		t.Error("expected an error, but did not get one")
+	}
+
+	msg := "cookie name 'nonexistent-cookie' not found"
+	if test.Error.Error() != msg {
+		t.Errorf("expected '%s', but got '%s' instead", msg, test.Error.Error())
+	}
+}
+
 func TestMustFunction(t *testing.T) {
 	test := NewTest("unit-test")
 

--- a/test_test.go
+++ b/test_test.go
@@ -20,7 +20,7 @@ type SampleObject struct {
 func init() {
 	api = httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == "POST" {
+			if r.Method == "POST" || r.Method == "PUT" {
 				data, _ := json.Marshal(SampleObject{
 					Name:    "unit-test",
 					Value:   100,
@@ -63,6 +63,19 @@ func TestPost(t *testing.T) {
 
 	sample := SampleObject{}
 	test = test.Post(api.URL, "/tests", nil).ParseResponseBody(&sample)
+	if sample.Name != "unit-test" {
+		t.Errorf("name response was %s, expected unit-test", sample.Name)
+	}
+	if !sample.Success {
+		t.Error("expected response success to be true")
+	}
+}
+
+func TestPut(t *testing.T) {
+	test := NewTest("unit-test")
+
+	sample := SampleObject{}
+	test = test.Put(api.URL, "/tests", nil).ParseResponseBody(&sample)
 	if sample.Name != "unit-test" {
 		t.Errorf("name response was %s, expected unit-test", sample.Name)
 	}

--- a/test_test.go
+++ b/test_test.go
@@ -225,6 +225,27 @@ func TestMustStatusMismatch(t *testing.T) {
 	}
 }
 
+func TestMustStringValueError(t *testing.T) {
+	test := NewTest("unit-test")
+
+	test.Error = fmt.Errorf("testing error")
+	test = test.MustStringValue("test", "test")
+
+	if test.Error == nil {
+		t.Errorf("expected an error, but did not get one")
+	}
+}
+
+func TestMustStringValueMismatch(t *testing.T) {
+	test := NewTest("unit-test")
+
+	test = test.MustStringValue("foo", "bar")
+
+	if test.Error == nil {
+		t.Errorf("expected an error, but did not get one")
+	}
+}
+
 func TestMustFunction(t *testing.T) {
 	test := NewTest("unit-test")
 

--- a/test_test.go
+++ b/test_test.go
@@ -267,6 +267,17 @@ func TestMustIntValueMismatch(t *testing.T) {
 	}
 }
 
+func TestMustError(t *testing.T) {
+	test := NewTest("unit-test")
+
+	test.Error = fmt.Errorf("testing error")
+	test = test.Must(mustNil)
+
+	if test.Error == nil {
+		t.Errorf("expected an error, but did not get one")
+	}
+}
+
 func TestMustFunction(t *testing.T) {
 	test := NewTest("unit-test")
 

--- a/test_test.go
+++ b/test_test.go
@@ -104,6 +104,16 @@ func TestMalformedUrl(t *testing.T) {
 	}
 }
 
+func TestBadRequestBody(t *testing.T) {
+	test := NewTest("unit-test")
+
+	// pass a clearly bogus request body to force a json parse error
+	test = test.Post(api.URL, "/tests", make(chan int))
+	if test.Error == nil {
+		t.Errorf("expected an error, but did not get one")
+	}
+}
+
 func TestAddDefaultHeader(t *testing.T) {
 	test := NewTest("unit-test").
 		AddHeader("Content-Type", "application/json")


### PR DESCRIPTION
This brings `test.go` to 95.1% coverage. Test report below:

github.com/stangles/irest/test.go:37:		NewTest			                100.0%
github.com/stangles/irest/test.go:54:		NewTest			                100.0%
github.com/stangles/irest/test.go:74:		AddHeader		                100.0%
github.com/stangles/irest/test.go:80:		AddCookie		                100.0%
github.com/stangles/irest/test.go:86:		Get				                100.0%
github.com/stangles/irest/test.go:92:		Post				                100.0%
github.com/stangles/irest/test.go:98:		Put				                100.0%
github.com/stangles/irest/test.go:103:	Delete			                100.0%
github.com/stangles/irest/test.go:107:		do			                	100.0%
github.com/stangles/irest/test.go:147:		ParseResponseBody		66.7%
github.com/stangles/irest/test.go:172:		MustStatus			        100.0%
github.com/stangles/irest/test.go:186:	MustStringValue			100.0%
github.com/stangles/irest/test.go:199:	MustIntValue			        100.0%
github.com/stangles/irest/test.go:217:		Must				        100.0%
github.com/stangles/irest/test.go:231:		SaveCookie			        100.0%

There were some error scenarios that I could not simulate in `ParseResponseBody`, which is why it isn't at 100% coverage. See below screenshot for more details.

![screen shot 2016-10-24 at 6 35 41 pm](https://cloud.githubusercontent.com/assets/2205356/19666504/d1ebe33c-9a18-11e6-808c-076ae4d77d1f.png)